### PR TITLE
Use `I18NBundle` for strings

### DIFF
--- a/android/assets/strings.properties
+++ b/android/assets/strings.properties
@@ -6,7 +6,7 @@
 viewSource=View source code
 leadDev=Lead developer:Marvin
 coDev=Co-developer:Martin
-repo=https://github.com/Crazy-Marvin/Halma
+repoURL=https://github.com/Crazy-Marvin/Halma
 
 # MainMenu
 newGame=New Game
@@ -22,4 +22,4 @@ online=Online
 offline=Offline
 square=Square
 star=Star
-start=Start Game
+startGame=Start Game

--- a/android/assets/strings.properties
+++ b/android/assets/strings.properties
@@ -1,0 +1,25 @@
+# English strings
+# If strings are missing in other languages, it will default to this
+
+
+# About
+viewSource=View source code
+leadDev=Lead developer:Marvin
+coDev=Co-developer:Martin
+repo=https://github.com/Crazy-Marvin/Halma
+
+# MainMenu
+newGame=New Game
+about=About
+help=Help
+
+# PlayConfig
+mode=Mode
+board=Board
+bots=Bots
+people=People
+online=Online
+offline=Offline
+square=Square
+star=Star
+start=Start Game

--- a/android/assets/strings_de.properties
+++ b/android/assets/strings_de.properties
@@ -6,7 +6,7 @@
 viewSource=Quellcode anzeigen
 leadDev=Hauptentwickler:Marvin
 coDev=Mitentwickler:Martin
-#repo - URL, same as English
+#repoURL
 
 # MainMenu #
 newGame=Neues Spiel
@@ -22,4 +22,4 @@ online=Online
 offline=Offline
 square=Platz
 star=Stern
-start=Spiel Starten
+startGame=Spiel Starten

--- a/android/assets/strings_de.properties
+++ b/android/assets/strings_de.properties
@@ -1,0 +1,25 @@
+# German translation
+# Automatic translations for test purposes
+# TODO: Get it correctly translated by a native speaker; use a font that supports umlauts
+
+# About #
+viewSource=Quellcode anzeigen
+leadDev=Hauptentwickler:Marvin
+coDev=Mitentwickler:Martin
+#repo - URL, same as English
+
+# MainMenu #
+newGame=Neues Spiel
+about=Uber
+help=Hilfe
+
+# PlayConfig #
+mode=Modus
+board=Vorstand
+bots=Bots
+people=Menschen
+online=Online
+offline=Offline
+square=Platz
+star=Stern
+start=Spiel Starten

--- a/core/src/rocks/poopjournal/halma/BaseScreen.java
+++ b/core/src/rocks/poopjournal/halma/BaseScreen.java
@@ -112,4 +112,8 @@ public abstract class BaseScreen extends ScreenAdapter {
         for(Actor a : actors)
             stage.addActor(a);
     }
+    protected String getString(String key) {
+        return halma.getBundle().get(key);
+    }
+
 }

--- a/core/src/rocks/poopjournal/halma/Halma.java
+++ b/core/src/rocks/poopjournal/halma/Halma.java
@@ -1,37 +1,33 @@
 package rocks.poopjournal.halma;
 
 import com.badlogic.gdx.Game;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.utils.I18NBundle;
+
 import rocks.poopjournal.halma.redesign.MainMenu;
 
 import java.util.Locale;
 
 public class Halma extends Game {
-	/*SpriteBatch batch;
-	Texture img;*/
+
+	private I18NBundle bundle;
 	
 	@Override
 	public void create () {
-		/*batch = new SpriteBatch();
-		img = new Texture("badlogic.jpg");*/
 		System.out.println("program start :)");
+
+		// Override to specific language with new Locale("de"), "en", etc.
+		Locale locale = Locale.getDefault();
 		System.out.println("your language is:");
-		System.out.println(Locale.getDefault().toString());
+		System.out.println(locale);
+		I18NBundle.setSimpleFormatter(true); // Ensure same behaviour on GWT and other platforms
+		bundle = I18NBundle.createBundle(Gdx.files.internal("strings"), locale);
+
 		setScreen(new MainMenu(this));
 	}
 
-	@Override
-	public void render () {
-		/*Gdx.gl.glClearColor(1, 0, 0, 1);
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		batch.begin();
-		batch.draw(img, 0, 0);
-		batch.end();*/
-		super.render();
+	I18NBundle getBundle() {
+		return bundle;
 	}
 
-	@Override
-	public void dispose () {
-		/*batch.dispose();
-		img.dispose();*/
-	}
 }

--- a/core/src/rocks/poopjournal/halma/redesign/About.java
+++ b/core/src/rocks/poopjournal/halma/redesign/About.java
@@ -18,12 +18,14 @@ public class About extends BaseScreen {
     private void create(){
         bgColor = Color.WHITE;
 
-        code = tb("View source code");
+        code = tb(getString("viewSource"));
         content = new Table(skin);
 
         content.defaults().padRight(stage.getWidth()/20);
-        content.add(lbl("Lead developer:"), lbl("Marvin")).row();
-        content.add(lbl("Co-developer:"), lbl("Martin"));
+        String[] leadDev = getString("leadDev").split(":");
+        content.add(lbl(leadDev[0] + ":"), lbl(leadDev[1])).row();
+        String[] coDev = getString("coDev").split(":");
+        content.add(lbl(coDev[0] + ":"), lbl(coDev[1]));
 
         content.pad(stage.getWidth()/35);
         layout.add(content).row();
@@ -45,6 +47,6 @@ public class About extends BaseScreen {
 
     @Override
     public void clicked(Actor a) {
-        if(code == a) Gdx.net.openURI("https://github.com/Crazy-Marvin/Halma");
+        if(code == a) Gdx.net.openURI(getString("repo"));
     }
 }

--- a/core/src/rocks/poopjournal/halma/redesign/MainMenu.java
+++ b/core/src/rocks/poopjournal/halma/redesign/MainMenu.java
@@ -23,9 +23,9 @@ public class MainMenu extends BaseScreen {
     private void create(){
         this.bgColor = Color.WHITE;
         icon = new Image(new Texture("redesign/ic_foreground.png")); icon.setScaling(Scaling.fit);
-        newGame = new TextButton("New game", skin, "Blue");
-        about = new TextButton("About", skin, "default");
-        help = new TextButton("Help", skin, "default");
+        newGame = new TextButton(getString("newGame"), skin, "Blue");
+        about = new TextButton(getString("about"), skin, "default");
+        help = new TextButton(getString("help"), skin, "default");
 
         addActorsToStage(icon, newGame, about, help);
         addButtonsToListener(help, about, newGame);

--- a/core/src/rocks/poopjournal/halma/redesign/PlayConfig.java
+++ b/core/src/rocks/poopjournal/halma/redesign/PlayConfig.java
@@ -31,7 +31,7 @@ public class PlayConfig extends BaseScreen {
 
         // TextButtons
         online = tb(getString("online")); offline = tb(getString("offline")); square = tb(getString("square"));
-        star = tb(getString("star")); startButton = tb(getString("start"), "Blue");
+        star = tb(getString("star")); startButton = tb(getString("startGame"), "Blue");
 
         // Images
         botUp = new Image(skin, "Plus"); botDown = new Image(skin, "Minus");

--- a/core/src/rocks/poopjournal/halma/redesign/PlayConfig.java
+++ b/core/src/rocks/poopjournal/halma/redesign/PlayConfig.java
@@ -21,16 +21,21 @@ public class PlayConfig extends BaseScreen {
         super(halma);
         bgColor = Color.WHITE;
 
+        // Tables
         settings = new Table(skin); onlineOffline = new Table(skin); boardType = new Table(skin);
         botCountTable = new Table(skin); peopleCountTable = new Table(skin);
 
-        mode = lbl("Mode"); board = lbl("Board"); bots = lbl("Bots");
-        people = lbl("People"); botCount = lbl("1"); peopleCount = lbl("1");
+        // Labels
+        mode = lbl(getString("mode")); board = lbl(getString("board")); bots = lbl(getString("bots"));
+        people = lbl(getString("people")); botCount = lbl("1"); peopleCount = lbl("1");
 
-        online = tb("Online"); offline = tb("Offline"); square = tb("Square");
-        star = tb("Star"); botUp = new Image(skin, "Plus"); botDown = new Image(skin, "Minus");
+        // TextButtons
+        online = tb(getString("online")); offline = tb(getString("offline")); square = tb(getString("square"));
+        star = tb(getString("star")); startButton = tb(getString("start"), "Blue");
+
+        // Images
+        botUp = new Image(skin, "Plus"); botDown = new Image(skin, "Minus");
         peopleUp = new Image(skin, "Plus"); peopleDown = new Image(skin, "Minus");
-        startButton = tb("Start Game", "Blue");
 
         settings.pad(stage.getWidth()/20);
         settings.defaults().pad(stage.getWidth()/40);


### PR DESCRIPTION
Proposal for consolidating the app's strings into properties files. This only affects the New Game and About pages (I get the impression everything under Help is planned to eventually be replaced), but it's trivial enough to extend further.

Don't put `strings_de.properties` into production as-is, as I don't speak the language. To support other languages, just create additional files such as `strings_fr.properties`. Ideally we'd have an in-app language selection screen, especially as I don't think `Locale.getDefault()` works correctly on GWT.